### PR TITLE
Fix duplicate word

### DIFF
--- a/content/en/notes/uiuc-cs450/lec02.md
+++ b/content/en/notes/uiuc-cs450/lec02.md
@@ -43,7 +43,7 @@ This means that a given relative change in the input causes a relative change in
 
 #### Stability and Accuracy
 
-An algorithm is **stable** if errors in the input do not grow significantly during the computation. **Stability** measures the sensitivity of an algorithm to to round-off and truncation errors.
+An algorithm is **stable** if errors in the input do not grow significantly during the computation. **Stability** measures the sensitivity of an algorithm to round-off and truncation errors.
 
 Stability (of an algorithm) is analogous to conditioning (of a problem):
 - Similarity: both relate to effects of perturbations.


### PR DESCRIPTION
## Summary
- fix duplicate word in stability definition

## Testing
- `make` *(fails: `ssg-content: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68769d3e93148327b912fa6c5f4ca8b8