### PR TITLE
Fix typos in docs

### DIFF
--- a/content/en/notes/vector-calculus/div-grad-curl/1-introduction.md
+++ b/content/en/notes/vector-calculus/div-grad-curl/1-introduction.md
@@ -22,7 +22,7 @@ Our discussion is based on three experimental facts:
 
 **1.** **Existence of electric charge.** There are two kinds of electric charge, positive and negative. Every material body contains electric charge. Often, zero net charge.
 
-**2.** **Coulomb's law.** The elctrostatic force between two charged particles is
+**2.** **Coulomb's law.** The electrostatic force between two charged particles is
 proportional to the product of their charges and inversely proportional to the square of their distance.
 
 The force on $q_0$ due to $q$ is given by

--- a/content/en/notes/vector-calculus/div-grad-curl/3-line-integrals-and-curl.md
+++ b/content/en/notes/vector-calculus/div-grad-curl/3-line-integrals-and-curl.md
@@ -112,8 +112,7 @@ The path integral around a closed curve is often called a **circulation**.
 
 ### The Curl
 
-Let us consider the circulation of $\mathbf{F}$ around a small rectangle parallel the $xy$
--plane:
+Let us consider the circulation of $\mathbf{F}$ around a small rectangle parallel to the $xy$-plane:
 
  ![](fig-III-11a.png)
 

--- a/content/en/notes/vector-calculus/div-grad-curl/problems/3/p1.md.i
+++ b/content/en/notes/vector-calculus/div-grad-curl/problems/3/p1.md.i
@@ -1,5 +1,5 @@
 **Problem III-1.**
-Use an argument like the one given in the text for the Coloumb force to
+Use an argument like the one given in the text for the Coulomb force to
 show that $\int_C \mathbf{F} \cdot \hat{\mathbf{t}} \\, ds = 0$ is independent
 of path for any central force $\mathbf{F}$.
 


### PR DESCRIPTION
## Summary
- fix `Coloumb` spelling
- fix `elctrostatic` spelling
- fix a sentence in the curl section

## Testing
- `make` *(fails: ssg-content not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881c557064c83278344ddcef0a1720e